### PR TITLE
Fix dependency type for spdx-expression-parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -886,14 +886,12 @@
     "spdx-exceptions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.0.0.tgz",
-      "integrity": "sha1-aoDpnx8z5ArPSX9qQwz0mWnwE6g=",
-      "dev": true
+      "integrity": "sha1-aoDpnx8z5ArPSX9qQwz0mWnwE6g="
     },
     "spdx-expression-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.0.tgz",
-      "integrity": "sha512-jbUCw8KGLTtZudkXDI2rTkWJ++O+nUZ/cD2GVgdFab36Smu7L1+5TIOHpPPtQU4hV5kiE+eh15cJk4vZxLPy/g==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.1.tgz",
+      "integrity": "sha512-uwTOyZVJS8xcEMfPApWDw2ZstSfdjrNuqzrz57p0FYx3Fiom76qBQUpeytoq1PZkCW6LytvO6vW9lf9nb2fClw=="
     },
     "spdx-license-ids": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "Christian Zommerfelds <aero_super@yahoo.com>"
   ],
   "dependencies": {
+    "spdx-expression-parse": "^2.0.1",
     "spdx-license-ids": "^2.0.1"
   },
   "devDependencies": {
     "defence-cli": "^1.0.1",
     "replace-require-self": "^1.0.0",
-    "spdx-expression-parse": "^2.0.0",
     "standard": "^8.6.0",
     "standard-markdown": "^2.3.0",
     "tape": "~4.0.0"


### PR DESCRIPTION
It is a runtime dependency not a dev dependency. The current configuration fails when doing production npm installs.

Also, excluding node_modules from source control so they don't show as pending changes.