### PR TITLE
threshold to correct

### DIFF
--- a/test.js
+++ b/test.js
@@ -446,3 +446,26 @@ test('Opt out of upgrades', function (test) {
     })
   test.end()
 })
+
+var thresholdExamples = {
+  ' Mit': 'MIT',
+  'mit': 'MIT',
+  'This is not MIT licensed': null,
+  'Anything except GPL': null
+}
+
+test('Threshold for correcting', function (test) {
+  Object.keys(thresholdExamples)
+    .forEach(function (input) {
+      var corrected = thresholdExamples[input]
+      test.test(input, function (test) {
+        test.equal(
+          correct(input, { upgrade: false }),
+          corrected,
+          'corrects "' + input + '" to "' + corrected + '"'
+        )
+        test.end()
+      })
+    })
+  test.end()
+})


### PR DESCRIPTION
Curious to know if there is interest in this direction. Feel free to close if not :)

This is a failing test right now because

```js
correct('This is not MIT licensed')
```

returns `'MIT'`

There's a lot of approaches here, and I am interested to know if this has been discussed at all.