### PR TITLE
Stop Maintaining a Contributors List in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Usage
+
 ```javascript
 var correct = require('spdx-correct')
 var assert = require('assert')
@@ -12,3 +14,9 @@ assert(correct('No idea what license') === null)
 assert(correct('GPL-3.0'), 'GPL-3.0-or-later')
 assert(correct('GPL-3.0', { upgrade: false }), 'GPL-3.0')
 ```
+
+## Contributors
+
+spdx-correct has benefited from the work of several contributors.
+See [the GitHub repository](https://github.com/jslicense/spdx-correct.js/graphs/contributors)
+for more information.

--- a/package.json
+++ b/package.json
@@ -2,12 +2,6 @@
   "name": "spdx-correct",
   "description": "correct invalid SPDX expressions",
   "version": "3.1.1",
-  "contributors": [
-    "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
-    "Christian Zommerfelds <aero_super@yahoo.com>",
-    "Tal Einat <taleinat@gmail.com>",
-    "Dan Butvinik <butvinik@outlook.com>"
-  ],
   "dependencies": {
     "spdx-expression-parse": "^3.0.0",
     "spdx-license-ids": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "spdx-correct",
   "description": "correct invalid SPDX expressions",
   "version": "3.1.1",
-  "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
   "contributors": [
     "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
     "Christian Zommerfelds <aero_super@yahoo.com>",


### PR DESCRIPTION
This PR removes `author` and `contributors` metadata from `package.json` and adds a link to the GitHub contributors page for the repo to `README.md`.
